### PR TITLE
Hit chance for attacks implemented

### DIFF
--- a/Assets/Prefabs/AI Units/Turret.prefab
+++ b/Assets/Prefabs/AI Units/Turret.prefab
@@ -154,7 +154,7 @@ Transform:
   m_Children:
   - {fileID: 2704055251100190590}
   m_Father: {fileID: 0}
-  m_RootOrder: 17
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1159365306716288852
 MeshFilter:
@@ -246,6 +246,7 @@ MonoBehaviour:
   agility: 5
   precision: 5
   constitution: 5
+  equippedWeapon: {fileID: 0}
   maxHP: 50
   immune: 0
   hostility: 2
@@ -256,7 +257,7 @@ MonoBehaviour:
     type: 3}
   currentHP: 0
   unitState: 0
-  actionTime: 10
+  actionTime: 0.8
   CharPortrait: {fileID: 8547787947617653108}
 --- !u!114 &7583036914056682796
 MonoBehaviour:

--- a/Assets/Prefabs/Units/BasicEnemyUnit.prefab
+++ b/Assets/Prefabs/Units/BasicEnemyUnit.prefab
@@ -151,6 +151,7 @@ MonoBehaviour:
   agility: 1
   precision: 1
   constitution: 1
+  equippedWeapon: {fileID: 0}
   maxHP: 100
   immune: 0
   hostility: 2
@@ -161,9 +162,8 @@ MonoBehaviour:
     type: 3}
   currentHP: 0
   unitState: 0
-  actionTime: 10
+  actionTime: 0.8
   CharPortrait: {fileID: 2347300628807073429}
-  CursorTexture: {fileID: 0}
 --- !u!114 &7892114624545858478
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -181,6 +181,7 @@ MonoBehaviour:
   abilitySprite: {fileID: 0}
   atkDamage: 25
   atkRange: 50
+  accuracy: 50
 --- !u!114 &5597729487216790004
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Units/BasicUnit.prefab
+++ b/Assets/Prefabs/Units/BasicUnit.prefab
@@ -161,7 +161,7 @@ MonoBehaviour:
     type: 3}
   currentHP: 0
   unitState: 0
-  actionTime: 8
+  actionTime: 0.8
   CharPortrait: {fileID: 0}
 --- !u!114 &7892114624545858478
 MonoBehaviour:

--- a/Assets/Scenes/LevelPrototype.unity
+++ b/Assets/Scenes/LevelPrototype.unity
@@ -460,6 +460,36 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
+      propertyPath: agility
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: strength
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: unitName
+      value: Headsman Turret
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: dexterity
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: precision
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: constitution
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
       propertyPath: equippedWeapon
       value: 
       objectReference: {fileID: 11400000, guid: d67a73874f05861469f91de155da93a1,
@@ -836,11 +866,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
-        type: 3}
-      propertyPath: actionTime
-      value: 10
-      objectReference: {fileID: 0}
     - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
       propertyPath: CharPortrait
@@ -1390,8 +1415,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
-      propertyPath: actionTime
-      value: 10
+      propertyPath: precision
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
@@ -1419,11 +1444,6 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 88d117937a7e5d145983de40f85f34f1, type: 2}
-    - target: {fileID: 4457893470198798407, guid: 65797fcb4bffaa648bc150e0f2bd908d,
-        type: 3}
-      propertyPath: m_IsTrigger
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 6736091198766071087, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
       propertyPath: m_RootOrder
@@ -1478,11 +1498,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7738742569409711224, guid: 65797fcb4bffaa648bc150e0f2bd908d,
-        type: 3}
-      propertyPath: m_Speed
-      value: 5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -2007,6 +2022,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
+      propertyPath: strength
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
+        type: 3}
       propertyPath: unitName
       value: Tactician
       objectReference: {fileID: 0}
@@ -2019,11 +2039,6 @@ PrefabInstance:
         type: 3}
       propertyPath: precision
       value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
-        type: 3}
-      propertyPath: actionTime
-      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
@@ -2051,11 +2066,6 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 03ce528c060bdaf49a9b3e0ad58399e2, type: 2}
-    - target: {fileID: 4457893470198798407, guid: 65797fcb4bffaa648bc150e0f2bd908d,
-        type: 3}
-      propertyPath: m_IsTrigger
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 6736091198766071087, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
       propertyPath: m_RootOrder
@@ -2110,11 +2120,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7738742569409711224, guid: 65797fcb4bffaa648bc150e0f2bd908d,
-        type: 3}
-      propertyPath: m_Speed
-      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7892114624545858478, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
@@ -2529,12 +2534,17 @@ PrefabInstance:
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
       propertyPath: agility
-      value: 5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
       propertyPath: strength
-      value: 5
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: unitName
+      value: Peacekeeper Turret
       objectReference: {fileID: 0}
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
@@ -2544,12 +2554,12 @@ PrefabInstance:
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
       propertyPath: precision
-      value: 5
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
       propertyPath: constitution
-      value: 5
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
@@ -2953,6 +2963,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
+      propertyPath: agility
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
+        type: 3}
       propertyPath: strength
       value: 10
       objectReference: {fileID: 0}
@@ -2964,17 +2979,12 @@ PrefabInstance:
     - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
       propertyPath: dexterity
-      value: 15
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
       propertyPath: precision
       value: 13
-      objectReference: {fileID: 0}
-    - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
-        type: 3}
-      propertyPath: actionTime
-      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
@@ -2984,7 +2994,7 @@ PrefabInstance:
     - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
       propertyPath: constitution
-      value: 7
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 146705667451509789, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
@@ -3002,11 +3012,6 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 6ef9b7c38e60d8548a235c9724b995bd, type: 2}
-    - target: {fileID: 4457893470198798407, guid: 65797fcb4bffaa648bc150e0f2bd908d,
-        type: 3}
-      propertyPath: m_IsTrigger
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 6736091198766071087, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
       propertyPath: m_RootOrder
@@ -3061,11 +3066,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7738742569409711224, guid: 65797fcb4bffaa648bc150e0f2bd908d,
-        type: 3}
-      propertyPath: m_Speed
-      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7892114624545858478, guid: 65797fcb4bffaa648bc150e0f2bd908d,
         type: 3}
@@ -3473,9 +3473,34 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
+      propertyPath: agility
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: strength
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: unitName
+      value: Peacekeeper Turret
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: precision
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: constitution
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
       propertyPath: equippedWeapon
       value: 
-      objectReference: {fileID: 11400000, guid: a7fc23ce51622b949b7c3a4aefc0b0ab,
+      objectReference: {fileID: 11400000, guid: 8de09c8879c226d498a31f7f69033da9,
         type: 2}
     - target: {fileID: 5953886048064918762, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
@@ -3779,12 +3804,17 @@ PrefabInstance:
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
       propertyPath: agility
-      value: 5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
       propertyPath: strength
-      value: 5
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: unitName
+      value: Peacekeeper Turret
       objectReference: {fileID: 0}
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
@@ -3794,12 +3824,12 @@ PrefabInstance:
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
       propertyPath: precision
-      value: 5
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
       propertyPath: constitution
-      value: 5
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}
@@ -4514,6 +4544,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Turret (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: agility
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: strength
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: unitName
+      value: Suppressor Turret
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: dexterity
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: precision
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
+        type: 3}
+      propertyPath: constitution
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 5251865484847204345, guid: 0bc1164b45bae7a419527f0bc7406684,
         type: 3}

--- a/Assets/Scripts/Abilities/Attack.cs
+++ b/Assets/Scripts/Abilities/Attack.cs
@@ -41,8 +41,21 @@ public class Attack : UnitAbility
                 Line.SetPosition(1, hit.point);
                 if (hit.collider.gameObject == target.gameObject)
                 {
-                    Line.startColor = Color.green;
-                    Line.endColor = Color.green;
+                
+
+                    //now factor in accuracy
+                    float hitRoll = Random.RandomRange(0, 1f);
+                    float hitChance = accuracy;
+                    Debug.Log(hitRoll);
+
+                    if (hitRoll < accuracy)
+                    {
+                        u.TakeDamage(atkDamage);
+                        Line.startColor = Color.green;
+                        Line.endColor = Color.green;
+                    }
+
+                 
                 }
             }
             else

--- a/Assets/Scripts/ActionBar & HealthBar Assets/ActionBarController.cs
+++ b/Assets/Scripts/ActionBar & HealthBar Assets/ActionBarController.cs
@@ -7,7 +7,7 @@ public class ActionBarController : MonoBehaviour
 {
     [Header("ActionBar Main Params")]
     public float actionBar = 0f;
-    public float maxActionBar = 100f;
+    public float maxActionBar = 0.800f;
 
     [Header("ActionBar Regen Params")]
     //[Range(0, 50)] public float actionDrain;

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -85,7 +85,7 @@ public class Unit : MonoBehaviour
     protected Unit followUnit;
 
     UnitAbility queuedAbility;
-    public float actionTime = 0.800f;
+    public float actionTime = 0.800f; //adjusted by QP to bring in line with balance sheet
 
     //Added by Ty
     ActionBarController actionBarController;
@@ -130,7 +130,7 @@ public class Unit : MonoBehaviour
         }
 
         //add constitution modifier to health
-        maxHP *= 1.0f + ((constitution - 5) * 0.1f); //much simpler
+        maxHP *= 1.0f + ((constitution - 5) * 0.1f); //much simpler ~QP
         //old:
         //if (constitution < 4)
         //{
@@ -142,7 +142,7 @@ public class Unit : MonoBehaviour
         //}
 
 
-        //move speed modifiers
+        //move speed modifiers ~weight factoring added by QP
         NavMeshAgent agentComponent = GetComponent<NavMeshAgent>();
 
         if(agentComponent != null)
@@ -150,10 +150,10 @@ public class Unit : MonoBehaviour
             agentComponent.speed += (.5f * (agility - 1.0f))*(2.0f / MathF.Max(equippedWeapon.weight-strength, 2));
         }
 
+        //action speed modifiers ~balance sheet calcs adjusted by QP
         //string debugmsg = "";
-        //debugmsg += $"Unit: {gameObject.name}\nBASE Action time: {actionTime}\n";
+        //debugmsg += $"Unit: {gameObject.name}\nWeapon: {equippedWeapon.name}\nWeapon DMG: {equippedWeapon.damage_per_shot}\nBASE Action time: {actionTime}\n";
 
-        //action speed modifiers
         actionTime = (2.0f*actionTime) - (float)(actionTime*Math.Pow(Math.E,0.02f*(dexterity-1)));
         //debugmsg += $"DEX-SCALED Action time: {actionTime}\n";
 
@@ -210,6 +210,7 @@ public class Unit : MonoBehaviour
         //Added and modified By Ty
         actionBarController.actionProgressUI.fillAmount = 1f - (actionBarController.actionBar / actionBarController.maxActionBar);
         healthBarController.healthProgressUI.fillAmount = healthBarController.healthBar / healthBarController.maxHealthBar;
+
         //modified by QP: actionRegen represents the actual time (ms) for the bar to fill, while maxActionBar is the base action speed
         actionBarController.actionBar += (actionBarController.maxActionBar / actionBarController.actionRegen) * Time.deltaTime;
 

--- a/Assets/Scripts/Weapons/Headsman.asset
+++ b/Assets/Scripts/Weapons/Headsman.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: Headsman
   m_EditorClassIdentifier: 
   weapon_name: Headsman
-  damage_per_shot: 50
+  damage_per_shot: 100
   shots_per_attack: 1
   baseAccuracy: 0.7
   range: 10
-  weight: 0
+  weight: 10

--- a/Assets/Scripts/Weapons/Suppressor.asset
+++ b/Assets/Scripts/Weapons/Suppressor.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: Suppressor
   m_EditorClassIdentifier: 
   weapon_name: 'Suppressor '
-  damage_per_shot: 100
+  damage_per_shot: 35
   shots_per_attack: 1
-  baseAccuracy: 1
+  baseAccuracy: 0.55
   range: 40
   weight: 1

--- a/Assets/Scripts/Weapons/playtest_weap 3.asset
+++ b/Assets/Scripts/Weapons/playtest_weap 3.asset
@@ -16,5 +16,5 @@ MonoBehaviour:
   damage_per_shot: 30
   shots_per_attack: 1
   baseAccuracy: 1.5
-  range: 12
+  range: 40
   weight: 12


### PR DESCRIPTION
<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
<!--- Can use bullet lists here to cover new additions, but give a bit more detail than what is given in commit messages --->
Added hit rolls into attacks. The result is printed out in the console. For now, it just uses the attack's base accuracy without any modifiers

~QP: Adjusted unit stats and calculations to be more in line with the balance spreadsheet:
> 
> Adjusted HP calculation to remove condition check (now implicit in the calculation)
>
> Rescaled fire rates/action times to run off of the 800ms base time listed in the balance sheet
> 
> Added strength/weight factor into movespeed calculations
> 

Renamed turrets to represent the weapons they wield

Miscellaneous balance fixes to turrets (see balance sheet)

## Please describe how to test
<!---Give the important steps needed for testing your main changes--->
Go into PrototypeLevel scene: do the characters move and shoot quickly?
Do the turrets feel (somewhat) distinct?

There are also a few lines for debug logging in the Unit.cs script (currently commented out) that might help for tracking calcs

## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->

## Issue worked on
<!---Paste in a link to the issue this PR addresses--->
https://github.com/RohitK-RIT/603_G5_DataDrivenRPG/issues/49
https://github.com/RohitK-RIT/603_G5_DataDrivenRPG/issues/39

## What Week of the 603 cycle is this due in?
<!---Only need to indicate here which week/deliverable the PR is for--->