### PR TITLE
Turret attack display

### DIFF
--- a/Assets/Prefabs/AI Units/Turret.prefab
+++ b/Assets/Prefabs/AI Units/Turret.prefab
@@ -133,6 +133,7 @@ GameObject:
   - component: {fileID: 7583036914056682796}
   - component: {fileID: 3971062894701759433}
   - component: {fileID: 3208420799909690633}
+  - component: {fileID: 9161369661000114405}
   m_Layer: 7
   m_Name: Turret
   m_TagString: Untagged
@@ -246,7 +247,6 @@ MonoBehaviour:
   agility: 5
   precision: 5
   constitution: 5
-  equippedWeapon: {fileID: 0}
   maxHP: 50
   immune: 0
   hostility: 2
@@ -257,6 +257,7 @@ MonoBehaviour:
   unitState: 0
   actionTime: 3.3
   CharPortrait: {fileID: 8547787947617653108}
+  equippedWeapon: {fileID: 0}
 --- !u!114 &7583036914056682796
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -311,6 +312,112 @@ MonoBehaviour:
   description: Ability Description
   abilitySprite: {fileID: 0}
   atkDamage: 30
+  accuracy: 50
+  SelectionCursor: {fileID: 0}
+--- !u!120 &9161369661000114405
+LineRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 838606811261842063}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10306, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Positions:
+  - {x: 0, y: 0, z: 0}
+  - {x: 1, y: 0, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 0.2
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 1, g: 0, b: 0, a: 1}
+      key1: {r: 1, g: 0, b: 0, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 1
+      m_ColorSpace: 0
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 0
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_MaskInteraction: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
 --- !u!1001 &1775833829844556370
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AI/AIPerception.cs
+++ b/Assets/Scripts/AI/AIPerception.cs
@@ -18,6 +18,7 @@ namespace AI
         public List<Unit> VisibleUnits { get; private set; }
 
         private Vector3 EyePosition => transform.position + eyeOffset;
+        public float SightDistance => sightDistance;
 
         private Mesh _mesh;
         private int _count;

--- a/Assets/Scripts/AI/Turret/AIAttack.cs
+++ b/Assets/Scripts/AI/Turret/AIAttack.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Linq;
 using UnityEngine;
 
 namespace AI.Turret
@@ -6,26 +7,125 @@ namespace AI.Turret
     public class AIAttack : UnitAbility
     {
         public float atkDamage = 25f;
+        public float accuracy = 50f;
+        [SerializeField] Texture2D SelectionCursor;
 
         Unit target;
 
-        public override void Execute()
+        //Added by Ty
+        protected LineRenderer Line;
+        private float _atkRange;
+        private AIPerception _perception;
+
+        private void Start()
         {
-            if(!GetComponent<AIPerception>().VisibleUnits.Contains(target))
-                return;
-            
+            Line = GetComponent<LineRenderer>();
+            Line.enabled = false;
+            _atkRange = GetComponent<AIPerception>().SightDistance;
+            _perception = GetComponent<AIPerception>();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
             if (target)
             {
-                target.TakeDamage(atkDamage);
+                Vector3 origin = transform.position;
+                origin.y += 0.5f;
+                Vector3 dest = target.transform.position;
+                dest.y += 0.5f;
+
+                Line.SetPosition(0, origin);
+                Line.startColor = Color.red;
+                Line.endColor = Color.red;
+
+                if (_perception.VisibleUnits.Contains(target)) // ignore other friendly units
+                {
+                    Line.SetPosition(1, target.transform.position);
+
+                    Line.startColor = Color.cyan;
+                    Line.endColor = Color.cyan;
+                }
+                else
+                {
+                    Line.SetPosition(1, origin + (dest - origin).normalized * _atkRange);
+                }
+            }
+        }
+
+        public override void Execute()
+        {
+            if (target)
+            {
+                target.OnKilled -= Cancel;
+
+                Vector3 origin = transform.position;
+                origin.y += 0.5f;
+                Vector3 dest = target.transform.position;
+                dest.y += 0.5f;
+
+                Line.SetPosition(0, origin);
+                Line.startColor = Color.red;
+                Line.endColor = Color.red;
+                Line.widthMultiplier = 0.75f;
+
+                // Check if target still in sight; deal dmg to whatever is hit (which may not be the target if another enemy unit is in the way)
+                if (_perception.VisibleUnits.Contains(target))
+                {
+                    Line.SetPosition(1, target.transform.position);
+                    
+                    //now factor in accuracy
+                    var hitRoll = Random.Range(0, 1f);
+                    var hitChance = accuracy;
+                    if (hitRoll < accuracy)
+                    {
+                        target.TakeDamage(atkDamage);
+                        Line.startColor = Color.green;
+                        Line.endColor = Color.green;
+                    }
+                }
+                else
+                {
+                    Line.SetPosition(1, origin + (dest - origin).normalized * _atkRange);
+                }
+
+                target = null;
+                StartCoroutine(shootLine());
             }
 
             base.Execute();
         }
 
+        IEnumerator shootLine()
+        {
+            yield return new WaitForSeconds(.5f);
+            Line.enabled = false;
+            Line.widthMultiplier = 0.2f;
+        }
+
         public void Queue(Unit unit)
         {
             target = unit;
+            Queue();
+        }
+
+        public override void Queue()
+        {
+            Line.enabled = true;
+            if (target)
+                target.OnKilled -= Cancel;
+            target.OnKilled += Cancel;
             base.Queue();
+        }
+
+        void Cancel(Unit t)
+        {
+            if (!base.Cancel())
+                return;
+
+            Line.enabled = false;
+            target = null;
         }
     }
 }


### PR DESCRIPTION
<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
<!--- Can use bullet lists here to cover new additions, but give a bit more detail than what is given in commit messages --->
Turrets now render a line while attacking
## Please describe how to test
<!---Give the important steps needed for testing your main changes--->
1. Make the players stand in front of the turret.
2. After it's done waiting it'll attack by rendering a line.
## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->
![image](https://github.com/RohitK-RIT/603_G5_DataDrivenRPG/assets/145331737/bcdc5355-83ba-48ee-b049-d3c93d3b1c8f)
## Issue worked on
<!---Paste in a link to the issue this PR addresses--->
#48 
## What Week of the 603 cycle is this due in?
<!---Only need to indicate here which week/deliverable the PR is for--->
Week 2 / Beta